### PR TITLE
fix: Fix row count metrics when processing `BATCH` messages by returning actual rows loaded from `COPY INTO`, not file count

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -583,7 +583,10 @@ class SnowflakeConnector(SQLConnector):
             )
             self.logger.debug("Copying with SQL: %s", copy_statement)
             result = conn.execute(copy_statement, **kwargs)
-            return result.rowcount
+            # COPY INTO rowcount = number of files, not rows.
+            # Fetch the result set and sum the rows_loaded column instead.
+            rows = result.fetchall()
+            return sum(r[3] for r in rows) if rows else result.rowcount
 
     def drop_file_format(self, file_format: str) -> None:
         """Drop a file format in the schema.


### PR DESCRIPTION
Snowflake COPY INTO rowcount = number of files loaded (always 1 per
batch file), not rows. Fetch the result set and sum rows_loaded (col 3)
to get the true record count emitted by record_counter_metric.
