### PR TITLE
fix: make file format name unique per sink to avoid cross-owner clobbering

### DIFF
--- a/target_snowflake/sinks.py
+++ b/target_snowflake/sinks.py
@@ -108,8 +108,16 @@ class SnowflakeSink(SQLSink[SnowflakeConnector]):
             self.logger.info("load_method=overwrite: truncating %s", self.full_table_name)
             self.connector.truncate_table(self.full_table_name)
 
+        # Use a unique name per sink instance. A static, stream-derived name is
+        # shared across overlapping sinks (e.g. when a SCHEMA message archives the
+        # old sink and creates a new one) and across concurrent target processes
+        # loading the same stream into the same schema. In those cases one owner's
+        # CREATE OR REPLACE / DROP FILE FORMAT clobbers a file format another sink
+        # is actively using, causing "File format ... does not exist" during
+        # COPY/MERGE. The uuid keeps each sink's file format isolated while still
+        # creating/dropping it only once per sink (not per batch).
         self._file_format_name = (
-            f'{self.database_name}.{self.schema_name}."tf-{self.stream_name}"'
+            f'{self.database_name}.{self.schema_name}."tf-{self.stream_name}-{uuid4()}"'
         )
         self.connector.create_file_format(file_format=self._file_format_name)
 


### PR DESCRIPTION
## Problem

Loads were failing with:

```
snowflake.connector.errors.ProgrammingError: 002003 (02000): SQL compilation error:
File format '<REDACTED>' does not exist or not authorized.
```

during `COPY INTO` / `MERGE`.

## Root cause

This is a regression from c3ff390 ("perf: reuse file format per stream", #6). That commit changed the file format name from a **per-batch unique** name:

```python
sync_id = f"{self.stream_name}-{uuid4()}"
file_format = f'...."{sync_id}"'   # globally unique
```

(created right before COPY/MERGE, dropped immediately after) to a **static, stream-derived** name created once in `setup()` and dropped in `clean_up()`:

```python
self._file_format_name = f'{self.database_name}.{self.schema_name}."tf-{self.stream_name}"'
```

That static name is no longer unique, so the lifecycle of one file format object now spans multiple owners that can clobber each other:

1. **Overlapping sinks for the same stream.** When a tap re-emits a `SCHEMA` message with a changed schema/key_properties (common with `tap-mysql` on long runs), the SDK archives the old sink into `_sinks_to_clear` and creates a new one. The new sink's `setup()` runs `CREATE OR REPLACE FILE FORMAT` on the **same** name while the old sink is still draining against it; at end-of-pipe the old sink's `clean_up()` `DROP`s that shared name.
2. **Concurrent target processes** loading the same stream into the same schema derive the **identical** name. One process's `clean_up()` `DROP`s the format another is mid-`COPY` on.

A transient S3 `ReadTimeoutError` (PUT retry) widens the window enough for another owner's `CREATE OR REPLACE` / `DROP` to land between the upload and the COPY.

## Fix

Reintroduce a `uuid4` into the file format name so each sink owns and drops its own file format, while keeping the perf win of c3ff390 (create/drop once per sink, not per batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)